### PR TITLE
ROCANA-11457: Fork cm_api and update to deploy to Rocana Nexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+Rocana Fork
+===========
+
+This is a fork of [cloudera/cm_api](https://github.com/cloudera/cm_api).
+
+The fork was originally performed to get around an issue that may be resolved in https://github.com/cloudera/cm_api/pull/63.
+This fork may no longer be needed once that has merged, and another release of the original repo is made.
+
 Cloudera Manager RESTful API Clients
 ====================================
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.cloudera.api</groupId>
   <artifactId>cloudera-manager-api</artifactId>
   <name>Cloudera Manager API</name>
-  <version>5.12.0</version>
+  <version>5.12.0-rocana1.0.0-SNAPSHOT</version>
 
   <properties>
     <cxf.version>2.7.7</cxf.version>
@@ -20,14 +20,14 @@
 
   <distributionManagement>
     <repository>
-      <id>cdh.releases.repo</id>
-      <url>http://maven.jenkins.cloudera.com:8081/artifactory/cdh-staging-local</url>
-      <name>CDH Releases Repository</name>
+      <id>com.rocana.releases</id>
+      <name>Rocana Release Repository</name>
+      <url>http://repository.rocana.com/content/repositories/com.scalingdata.releases/</url>
     </repository>
     <snapshotRepository>
-      <id>cdh.snapshots.repo</id>
-      <url>http://maven.jenkins.cloudera.com:8081/artifactory/libs-snapshot-local</url>
-      <name>CDH Snapshots Repository</name>
+      <id>com.rocana.snapshots</id>
+      <name>Rocana Snapshots Repository</name>
+      <url>http://repository.rocana.com/content/repositories/com.scalingdata.snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
* merge against base cm5-5.12.0-rocana
* Followed [instructions](https://rocana-docs.herokuapp.com/code/java-forking-libraries) for a new forked repo
* updated version to `5.12.0-rocana1.0.0-SNAPSHOT`
* Updated distribution management with Rocana URLs
* Updated README with fork reasons