### PR TITLE
ROCANA-11477: Fix AnnotationIntrospector.Pair usage in cm_api

### DIFF
--- a/java/src/main/java/com/cloudera/api/ApiObjectMapper.java
+++ b/java/src/main/java/com/cloudera/api/ApiObjectMapper.java
@@ -16,10 +16,10 @@
 
 package com.cloudera.api;
 
-import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 
 import java.text.DateFormat;
@@ -38,7 +38,7 @@ public class ApiObjectMapper extends ObjectMapper {
 
     // Allow JAX-B annotations.
     setAnnotationIntrospector(
-        new AnnotationIntrospector.Pair(
+        new AnnotationIntrospectorPair(
             getSerializationConfig().getAnnotationIntrospector(),
             new JaxbAnnotationIntrospector()));
 


### PR DESCRIPTION
* Replaces use of `AnnotationIntrospector.Pair` with `AnnotationIntrospectorPair`
as recommended by the [jackson 2.1 javadoc](https://fasterxml.github.io/jackson-databind/javadoc/2.1.0/com/fasterxml/jackson/databind/AnnotationIntrospector.html)
* This enables projects using newer versions of Jackson to include the API without problem
because `AnnotationIntrospector.Pair` is removed in Jackson 2.3
* Same change as https://github.com/cloudera/cm_api/pull/63, but against our custom branch